### PR TITLE
Fix missing endif in autoload

### DIFF
--- a/ftdetect/requirements.vim
+++ b/ftdetect/requirements.vim
@@ -34,7 +34,7 @@ function! Requirements_matched_filename(filename)
     return 0
 endfunction
 
-au BufNewFile,BufRead *.{txt,in} if s:isRequirementsFile() | set ft=requirements
+au BufNewFile,BufRead *.{txt,in} if s:isRequirementsFile() | set ft=requirements | endif
 au BufNewFile,BufRead *.pip set ft=requirements
 
 " vim: et sw=4 ts=4 sts=4:


### PR DESCRIPTION
I'm using [Vim-bootstrap](https://github.com/avelino/vim-bootstrap) and I tried to add the following line to my `vimrc`:

`autocmd BufRead,BufNewFile jrnl*.txt set fo+=t tw=50`

It didn't change anything. So, after disabling the plugins one by one, I found that `requirements.txt.vim` was causing the problem. I checked the code of `ftdetect/requirements.txt` and finally I found an unnoticed missing `| endif` in an autoload.

I hope it will help to other requirements.txt.vim users.