### PR TITLE
Fix editable option in examples

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -25,10 +25,10 @@ name @ gopher:/foo/com"
 foobar[quux]<2,>=3; os_name=='a'
 
 # VCS repositories
-[-e] git+git://git.myproject.org/MyProject#egg=MyProject # Git
-[-e] git://git.myproject.org/MyProject.git@v1.0#egg=MyProject
-[-e] hg+https://hg.myproject.org/MyProject#egg=MyProject # Mercurial
-[-e] hg+http://hg.myproject.org/MyProject@da39a3ee5e6b#egg=MyProject
-[-e] svn+http://svn.myproject.org/svn/MyProject/trunk@2019#egg=MyProject # Subversion
-[-e] bzr+ssh://user@myproject.org/MyProject/trunk#egg=MyProject # Bazaar
-[-e] bzr+https://bzr.myproject.org/MyProject/trunk@2019#egg=MyProject
+-e git+git://git.myproject.org/MyProject#egg=MyProject # Git
+-e git://git.myproject.org/MyProject.git@v1.0#egg=MyProject
+-e hg+https://hg.myproject.org/MyProject#egg=MyProject # Mercurial
+-e hg+http://hg.myproject.org/MyProject@da39a3ee5e6b#egg=MyProject
+-e svn+http://svn.myproject.org/svn/MyProject/trunk@2019#egg=MyProject # Subversion
+-e bzr+ssh://user@myproject.org/MyProject/trunk#egg=MyProject # Bazaar
+-e bzr+https://bzr.myproject.org/MyProject/trunk@2019#egg=MyProject


### PR DESCRIPTION
Removes square brackets around `-e` option, which where presumably have been copy-pasted from manual.