### PR TITLE
Support comments after environment markers

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -19,7 +19,7 @@ zope.interface==4.2.0
 
 # Examples from PEP508
 # c.f. https://www.python.org/dev/peps/pep-0508/
-requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7"
+requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7" # Comment
 pip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686
 name @ gopher:/foo/com"
 foobar[quux]<2,>=3; os_name=='a'

--- a/syntax/requirements.vim
+++ b/syntax/requirements.vim
@@ -37,7 +37,7 @@ syn match requirementsPackageName "\v^([a-zA-Z0-9][a-zA-Z0-9\-_\.]*[a-zA-Z0-9])"
 syn match requirementsExtras "\v\[\S+\]"
 syn match requirementsVersionControls "\v(git\+?|hg\+|svn\+|bzr\+)\S+"
 syn match requirementsURLs "\v(\@\s)?(https?|ftp|gopher)://?[^\s/$.?#].\S*"
-syn match requirementsEnvironmentMarkers "\v;\s.+$"
+syn match requirementsEnvironmentMarkers "\v;\s[^#]+"
 
 hi link requirementsComment Comment
 hi link requirementsCommandOption Special


### PR DESCRIPTION
For example:

    package; python_version < '3' # Comment

Previously, the environment marker syntax group matched to the end of
the line and didn't stop at the comment character (`#`).