### PR TITLE
Fix underline of package names starting with git

### DIFF
--- a/syntax/requirements.vim
+++ b/syntax/requirements.vim
@@ -35,7 +35,7 @@ syn match requirementsCommandOption "\v^\[?--?[a-zA-Z\-]*\]?"
 syn match requirementsVersionSpecifiers "\v(\=\=\=?|\<\=?|\>\=?|\~\=|\!\=)"
 syn match requirementsPackageName "\v^([a-zA-Z0-9][a-zA-Z0-9\-_\.]*[a-zA-Z0-9])"
 syn match requirementsExtras "\v\[\S+\]"
-syn match requirementsVersionControls "\v(git\+?|hg\+|svn\+|bzr\+)\S+"
+syn match requirementsVersionControls "\v(git\+|hg\+|svn\+|bzr\+)\S+"
 syn match requirementsURLs "\v(\@\s)?(https?|ftp|gopher)://?[^\s/$.?#].\S*"
 syn match requirementsEnvironmentMarkers "\v;\s[^#]+"
 


### PR DESCRIPTION
Package names starting with git were underlined as if they were a git repo.
Example: gitpython