### PR TITLE
change default commentstring to compatible with spec

### DIFF
--- a/after/ftplugin/requirements.vim
+++ b/after/ftplugin/requirements.vim
@@ -33,4 +33,6 @@ if executable('pip-compile')
         setlocal makeprg=pip-compile\ %
     endif
 endif
+
+setlocal commentstring=#\ %s
 " vim: et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Thanks for the plugin!

This PR just adds `commentstring` setting to `after/ftplugin` to change the default setting (`"/*%s*/"`) to format that's compatible with the specification for requirements.txt file.

This makes it possible to automatically comment/uncomment lines using plugins like `commentary.vim`.