### PR TITLE
Fix #20

### DIFF
--- a/syntax/requirements.vim
+++ b/syntax/requirements.vim
@@ -39,14 +39,14 @@ syn match requirementsVersionControls "\v(git\+?|hg\+|svn\+|bzr\+).*://.\S+"
 syn match requirementsURLs "\v(\@\s)?(https?|ftp|gopher)://?[^\s/$.?#].\S*"
 syn match requirementsEnvironmentMarkers "\v;\s[^#]+"
 
-hi link requirementsComment Comment
-hi link requirementsCommandOption Special
-hi link requirementsVersionSpecifiers Boolean
-hi link requirementsPackageName Identifier
-hi link requirementsExtras Type
-hi link requirementsVersionControls Underlined
-hi link requirementsURLs Underlined
-hi link requirementsEnvironmentMarkers Macro
+hi def link requirementsComment Comment
+hi def link requirementsCommandOption Special
+hi def link requirementsVersionSpecifiers Boolean
+hi def link requirementsPackageName Identifier
+hi def link requirementsExtras Type
+hi def link requirementsVersionControls Underlined
+hi def link requirementsURLs Underlined
+hi def link requirementsEnvironmentMarkers Macro
 
 let b:current_syntax = "requirements"
 


### PR DESCRIPTION
Now it can work.

BTW. `autoload/*.vim`, `plugin/*.vim` don't have any valid code. Why not delete
them? Although it is trivial, delete them can also save some time. And Why use `after/ftplugin` not `ftplugin`? In my environment, `ftplugin` seems can work, too.
And according to `:h compiler`, we shouldn't set `makeprg` directly, a correct
method is create a file named `compiler/pip-compier.vim`, which content is
setting makeprg and error message format.
