### PR TITLE
Add augroup

### DIFF
--- a/ftdetect/requirements.vim
+++ b/ftdetect/requirements.vim
@@ -55,7 +55,10 @@ function! Requirements_matched_filename(filename)
     return 0
 endfunction
 
-au BufNewFile,BufRead *.{txt,in} if s:isRequirementsFile() | set ft=requirements | endif
-au BufNewFile,BufRead *.pip set ft=requirements
+augroup requirements
+    autocmd!
+    au BufNewFile,BufRead *.{txt,in} if s:isRequirementsFile() | set ft=requirements | endif
+    au BufNewFile,BufRead *.pip set ft=requirements
+augroup END
 
 " vim: et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Fix #27

See `:h augroup`, it can disable these autocmds are run repeatedly.

And I notice `t/test_ftdetect.vim` use `Requirements_matched_filename(filename)`
and I am not sure if I change it to autoload function, the test can pass. So it
is determined by you.

Thanks.
