### PR TITLE
Remove augroup

### DIFF
--- a/ftdetect/requirements.vim
+++ b/ftdetect/requirements.vim
@@ -55,11 +55,8 @@ function! Requirements_matched_filename(filename)
     return 0
 endfunction
 
-augroup requirements
-    autocmd!
-    au BufNewFile,BufRead *.{txt,in} if s:isRequirementsFile() | set ft=requirements | endif
-    au BufNewFile,BufRead *.pip set ft=requirements
-    au BufNewFile,BufRead * if !did_filetype() | call requirements#shebang() | endif
-augroup END
+au BufNewFile,BufRead *.{txt,in} if s:isRequirementsFile() | set ft=requirements | endif
+au BufNewFile,BufRead *.pip set ft=requirements
+au BufNewFile,BufRead * if !did_filetype() | call requirements#shebang() | endif
 
 " vim: et sw=4 ts=4 sts=4:


### PR DESCRIPTION
See bullet number 2 under `:help ftdetect`:
> *Note* that there is no "augroup" command, this has already been done when sourcing your file.

---

Vim's builtin `filetype.vim` already sets up an augroup (`filetypedetect`) before it sources all `ftdetect/*.vim` files. Creating augroups within an ftdetect file causes the autocmds (and also the autocmds from *all later plugin ftdetects*) to no longer be a part of the `filetypedetect` augroup.

This causes later problems, such as `:filetype detect` not properly setting the filetype, since it only executes `filetypedetect` autocmds.