### PR TITLE
Syntax: Add a missing whitespace requirement to comments

### DIFF
--- a/syntax/requirements.vim
+++ b/syntax/requirements.vim
@@ -37,7 +37,7 @@ syn region requirementsSubst matchgroup=requirementsSubstDelim start="\V${" end=
 syn region requirementsString matchgroup=requirementsStringDelim start=`'` skip=`\\'` end=`'`
 syn region requirementsString matchgroup=requirementsStringDelim start=`"` skip=`\\"` end=`"`
 syn match requirementsVersion "\v\d+[a-zA-Z0-9\.\-\*]*"
-syn region requirementsComment start="[ \t]*#" end="$"
+syn region requirementsComment start="\v(^|[ \t])#" end="$"
 syn match requirementsCommandOption "\v^\[?--?[a-zA-Z\-]*\]?"
 syn match requirementsVersionSpecifiers "\v(\=\=\=?|\<\=?|\>\=?|\~\=|\!\=)"
 syn match requirementsPackageName "\v^([a-zA-Z0-9][a-zA-Z0-9\-_\.]*[a-zA-Z0-9])"


### PR DESCRIPTION
According to the spec:

    A line that begins with # is treated as a comment and ignored.
    Whitespace followed by a # causes the # and the remainder of the line
    to be treated as a comment.

Before this patch the following had a mistakenly highlighted comment (pip doesn't accept this):

    numpy==2.1.3#not a comment

(There's no whitespace before the #).